### PR TITLE
display both default and non-default overrides for symbol

### DIFF
--- a/Contents/Sketch/legendifyArtboard/getLegendItemDescription.js
+++ b/Contents/Sketch/legendifyArtboard/getLegendItemDescription.js
@@ -2,23 +2,47 @@ function getLegendItemDescription({ layer, layerIndex, symbolsDictionary }) {
   const symbolMaster = layer.symbolMaster && layer.symbolMaster();
   const overrides = layer.overrides();
 
-  let description = '(' + layerIndex + ')  ' + symbolMaster.name() + '\n';
+  const availableOverrideNames = Array
+    .from(symbolMaster.availableOverrides())
+    .map(override => override.currentValue())
+    .map(value => symbolsDictionary[value])
+    .map(s => s && s.name())
+    .filter(Boolean);
 
-  for (const symbolKey in overrides) {
+  const defaultOverrides = Array.from(symbolMaster.overridePoints())
+    .reduce((defaultOverrides, overridePoint, index) => ({
+      ...defaultOverrides,
+      [overridePoint.layerID()]: {
+        type: overridePoint.layerName(),
+        value: availableOverrideNames[index]
+      }
+    }), {});
+
+  const descriptionParts = [
+    `(${layerIndex})  ${symbolMaster.name()}\n`
+  ];
+
+  for (let symbolKey in defaultOverrides) {
     const override = overrides[symbolKey];
 
-    if (symbolsDictionary[symbolKey]) {
-      description += '        ' + symbolsDictionary[symbolKey].name();
+    if (override && symbolsDictionary[symbolKey]) {
+      descriptionParts.push(`          + ${symbolsDictionary[symbolKey].name()}`);
 
       if (override.symbolID && symbolsDictionary[override.symbolID]) {
         const symbolName = symbolsDictionary[override.symbolID];
 
-        description += ` = ${symbolName.name()}\n`;
+        descriptionParts.push(` = ${symbolName.name()}\n`);
+      }
+    } else {
+      let defaultOverride = defaultOverrides[symbolKey];
+
+      if (defaultOverride.value) {
+        descriptionParts.push(`          - ${defaultOverride.type} = ${defaultOverride.value}\n`);
       }
     }
   }
 
-  return description;
+  return descriptionParts.join('');
 }
 
 module.exports = getLegendItemDescription;


### PR DESCRIPTION
<img width="1093" alt="screen shot 2018-04-03 at 9 09 30 pm" src="https://user-images.githubusercontent.com/5727408/38267174-53670a5a-3783-11e8-906c-f2d542bf5c5e.png">

default values have `-` prefix, changed ones `+`